### PR TITLE
ord(c) causes script to malfunction

### DIFF
--- a/volatility/plugins/tcaudit.py
+++ b/volatility/plugins/tcaudit.py
@@ -493,7 +493,7 @@ class TrueCryptPassphrase(common.AbstractWindowsCommand):
                     continue
                 # All characters in the range must be ASCII
                 chars = [
-                    c for c in passphrase if ord(c) >= 0x20 and ord(c) <= 0x7F
+                    c for c in passphrase if c >= 0x20 and c <= 0x7F
                 ]
                 if len(chars) != length:
                     continue


### PR DESCRIPTION
Hi, I was trying to execute truecrypt commands with volatility, and I got the following error : `c for c in passphrase if ord(c) >= 0x20 and ord(c) <= 0x7F
TypeError: ord() expected string of length 1, but int found`. I found this answer online to fix it : https://stackoverflow.com/a/19897878. Basically I just removed the "ord()" and it works now !