### PR TITLE
Encode to bytes when a string is passed

### DIFF
--- a/volatility/utils.py
+++ b/volatility/utils.py
@@ -157,7 +157,10 @@ def inet_ntop(address_family, packed_ip):
 def iterfind(data, string):
     """This function is called by the search_process_memory()
     method of windows, linux, and mac process objects"""
-
+    try:
+        string = string.encode()
+    except:
+        pass
     offset = data.find(string, 0)
     while offset >= 0:
         yield offset


### PR DESCRIPTION
Hi, I was doing forensic on a Ubuntu 16.04 image, and the command "linux_bash" was outputting the following error
 `File "volatility/volatility/utils.py", line 164, in iterfind
    offset = data.find(string, 0)
TypeError: argument should be integer or bytes-like object, not 'str'`

I found that the "string" parameter wasn't always a bytes-like object. I added a try-except to encode it when needed. This is a really quick fix, and I don't know the code at all. There is maybe a proper alternative.

The command was working properly after this.