### PR TITLE
Change pycrypto dependency to drop-in pycryptodome.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Pillow
-pycrypto
+pycryptodome
 distorm3
 yara-python


### PR DESCRIPTION
According to its authors, "PyCrypto 2.x is unmaintained, obsolete, and contains security vulnerabilities."  It also gives compile errors when trying to install via pip on macOS.

This patch switches the dependency to a drop-in replacement "pycrytodome"