### PR TITLE
Bug/check syscall arm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Pillow
-pycrypto
+pycryptodome
 distorm3
 yara-python

--- a/volatility/plugins/linux/check_syscall_arm.py
+++ b/volatility/plugins/linux/check_syscall_arm.py
@@ -116,7 +116,7 @@ class linux_check_syscall_arm(linux_common.AbstractLinuxARMCommand):
             else:
                 sym_name = "HOOKED"
 
-            yield (0[Address(i), Address(call_addr), str(sym_name)])
+            yield (0, [Address(i), Address(call_addr), str(sym_name)])
 
     def render_text(self, outfd, data):
         self.table_header(


### PR DESCRIPTION
This PR fixes the following error that is shown when running Volatility

```
 % python3 vol.py
Volatility Foundation Volatility Framework 3.0.0
/Users/joe/src/volatility/volatility/plugins/linux/check_syscall_arm.py:119: SyntaxWarning: 'int' object is not subscriptable; perhaps you missed a comma?
  yield (0[Address(i), Address(call_addr), str(sym_name)])
ERROR   : volatility.debug    : You must specify something to do (try -h)
```